### PR TITLE
Add some note try to fix yaml problem in config file

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -32,6 +32,7 @@
     3. 配置 IPv6 可以一定程度上缓解针对单 IP 的限流。
 4. 配置部分 Collector 的 Cookie：
     1. 目前只有 exhentai 需要。
+    2. yaml配置中 ipb_member_id项潜在的问题：因为该项值形式为1234567，作为yaml可能被反序列化为正数类型而不是预期的字符串类型，这可能造成程序崩溃，所以应该在config。yml中显式使用 `ipb_member_id: "1234567"` 格式使反序列化正常工作。
 5. KV 配置：
     1. 本项目内置使用了一个缓存服务，可以避免对一个图片集的重复同步。
     2. 请参考 [cloudflare-kv-proxy](https://github.com/ihciah/cloudflare-kv-proxy) 进行部署，并填写至配置文件。

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This code is only guaranteed to work correctly on MacOS (partial functionality) 
     2. Configure IPv6 to somewhat alleviate the flow restriction for single IP.
 4. Configure cookies for some Collectors.
     1. Currently, only exhentai is required.
+    2. Some potential issue with the field of cookie in yaml: as the ipb_member_id field has a format like 1234567, as yaml it could be decoded to `Integer` type rather tahn `String` type, which it is supposed to be. And it may cause problems and make the program panic. So in config.yml you should better use explicit `ipb_member_id: "1234567"` to make the decoding process work correctly.
 5. KV configuration
     1. This project uses a built-in caching service to avoid repeated synchronization of an image set.
     2. Please refer to [cloudflare-kv-proxy](https://github.com/ihciah/cloudflare-kv-proxy) for deployment and fill in the yaml file.

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -17,6 +17,9 @@ http:
 
 exhentai:
   ipb_pass_hash: xxx
+  # Use explicit String Literal in yaml to make the decoding process without possible errors
+  # For example  
+  # ipb_member_id: "1234567"
   ipb_member_id: xxx
   igneous: xxx
 


### PR DESCRIPTION
When I try to deploy it, I met a problem that the decoder cannot correctly inference the type of the value in field `ipb_member_id` without the explicit string literal type hint(such as double quote) and I have made a rough fix. I am not sure whether it would happen with all the version of serde, but I think it is necessary and worth to share it.
I updated both README in en and zh language and example file.
Maybe for the further solution of the problem, people should dig into the technical details of the crate serde?